### PR TITLE
Add `https` option to use https://localtunnel.me`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ zuul.yml
 tunnel:
   type: localtunnel # Optional and unnecessary here
   host: http://localtunnel.me
+  https: true # False by default, uses https for all connections
 ```

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function Tunnel(config) {
   var self = this;
 
   self.host = config.tunnel_host || (config.tunnel && config.tunnel.host) || 'http://localtunnel.me';
+  self.https = config.tunnel && config.tunnel.https;
   self.tunnel = undefined;
 }
 
@@ -19,8 +20,11 @@ Tunnel.prototype.connect = function(port, cb) {
       cb(err);
       return;
     }
-
-    var url = open_tunnel.url + '/__zuul';
+    var tunnelUrl = open_tunnel.url
+    if (self.https) {
+      tunnelUrl = tunnelUrl.replace(/^http:/, 'https:')
+    }
+    var url = tunnelUrl + '/__zuul';
     self.tunnel = open_tunnel;
     cb(null, url);
   });


### PR DESCRIPTION
For testing things like Service Worker, it's really convenient to be able to use the `https` scheme rather than the `http` scheme. This amends the docs and the code to add a new `https` option, false by default to preserve backwards compat.
